### PR TITLE
Fixed a typo in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Small and lightweight module to handle calls against the Azure Key Vault REST AP
 ## Install
 
 ```
-npm install re-az-authentication
+npm install re-az-keyvault
 ```
 
 ## Usage


### PR DESCRIPTION
It referenced re-az-authentication instead of re-az-keyvault