### PR TITLE
Add option to getSecrets() to return an object containing secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,40 @@ try {
 }
 ```
 
+To get multiple secrets in parallel and resolve it to an object with secret names
+as keys and secrets as values:
+
+```js
+let secrets;
+try {
+  secrets = await getSecrets(['name1', 'name2', 'name3'], { secretsObject: true });
+} catch (error) {
+  console.log(error);
+}
+
+// Example result:
+{
+  name1: "<secret>",
+  name2: "<secret>",
+  name3: "<secret>"
+}
+
+// To get specific versions.
+let secrets;
+try {
+  secrets = await getSecrets(['name1/version', 'name2/version', 'name3/version'], { secretsObject: true });
+} catch (error) {
+  console.log(error);
+}
+
+// Example result:
+{
+  name1: "<secret>",
+  name2: "<secret>",
+  name3: "<secret>"
+}
+```
+xs
 #### `listSecrets()`
 
 To list all secrets:

--- a/lib/keyvault.js
+++ b/lib/keyvault.js
@@ -85,11 +85,15 @@ class KeyVault {
 
   /**
    * Get secrets by parallel calls.
-   * @param {array} names Names of secrets to fetch. To get a specific version of a secret,
+   * @param {Array} names Names of secrets to fetch. To get a specific version of a secret,
    * specify name like 'name/version'.
-   * @returns {array} Returns an array of secrets REST API JSON object.
+   * @param {object}
+   * @returns {Promise<Array>|Promise<object>} Resolves to an array of secrets REST API JSON object.
+   * If options: { secretsObject: true } is passed it resolves to an object instead containing
+   * the secret names as keys and the secrets as the values.
    */
-  async getSecrets(names) {
+  async getSecrets(names, options) {
+    let opts = options ? options : {};
 
     let secretPromises = [];
     for (let i = 0; i < names.length; i++) {
@@ -112,6 +116,16 @@ class KeyVault {
 
     if (errors.length !== 0) {
       throw new Error('One or more secrets could not be fetched.');
+    }
+
+    if (opts.secretsObject && opts.secretsObject === true) {
+      let secretsObj = {};
+      secrets.forEach(secret => {
+        let idParts = secret.id.split('/');
+        secretsObj[idParts[idParts.length-2]] = secret.value;
+      });
+
+      secrets = secretsObj;
     }
 
     return secrets;

--- a/lib/keyvault.js
+++ b/lib/keyvault.js
@@ -87,7 +87,9 @@ class KeyVault {
    * Get secrets by parallel calls.
    * @param {Array} names Names of secrets to fetch. To get a specific version of a secret,
    * specify name like 'name/version'.
-   * @param {object}
+   * @param {object} [options] Object containing options.
+   * @param {boolean} [options.secretsObject] If true, it will resolve to an object with
+   * secret names as key and secrets as values. Defaults to false.
    * @returns {Promise<Array>|Promise<object>} Resolves to an array of secrets REST API JSON object.
    * If options: { secretsObject: true } is passed it resolves to an object instead containing
    * the secret names as keys and the secrets as the values.

--- a/test/keyvault.spec.js
+++ b/test/keyvault.spec.js
@@ -234,6 +234,40 @@ describe('KeyVault', () => {
         });
     });
 
+    it('should fetch all secrets and return them as a key/value pair (object) if secretsObject: true is passed in options', () => {
+
+      let getStub = sinon.stub(webreq, 'get');
+
+      getStub.onCall(0).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret1/1', value: '1' } });
+      getStub.onCall(1).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret2/1', value: '2' } });
+      getStub.onCall(2).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret3/1', value: '3' } });
+
+      return keyvault.getSecrets(['secret1','secret2','secret3'], { secretsObject: true })
+        .then(secrets => {
+          expect(typeof secrets === 'object');
+          expect(secrets['secret1']).to.equal('1');
+          expect(secrets['secret2']).to.equal('2');
+          expect(secrets['secret3']).to.equal('3');
+        });
+    });
+
+    it('should fetch all secrets (with version) and return them as a key/value pair (object) if secretsObject: true is passed in options', () => {
+
+      let getStub = sinon.stub(webreq, 'get');
+
+      getStub.onCall(0).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret1/1', value: '1' } });
+      getStub.onCall(1).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret2/1', value: '2' } });
+      getStub.onCall(2).resolves({ statusCode: 200, body: { id: 'https://kv.keyvaultbaseurl/secrets/secret3/1', value: '3' } });
+
+      return keyvault.getSecrets(['secret1/1','secret2/1','secret3/1'], { secretsObject: true })
+        .then(secrets => {
+          expect(typeof secrets === 'object');
+          expect(secrets['secret1']).to.equal('1');
+          expect(secrets['secret2']).to.equal('2');
+          expect(secrets['secret3']).to.equal('3');
+        });
+    });
+
     it('should throw if one ore more secrets could not be fetched', () => {
 
       let getStub = sinon.stub(webreq, 'get');


### PR DESCRIPTION
Does not break initial funcitonality. But using the option `secretsObject: true` will result in another output type (object instead of an array). This is documented in the JSDocs for the function, and in the README.